### PR TITLE
Allow debuging Lua built as a DLL

### DIFF
--- a/LuaDkmDebuggerComponent/LocalComponent.cs
+++ b/LuaDkmDebuggerComponent/LocalComponent.cs
@@ -1964,7 +1964,9 @@ namespace LuaDkmDebuggerComponent
 
                 var processData = DebugHelpers.GetOrCreateDataItem<LuaLocalProcessData>(process);
 
-                if (nativeModuleInstance.FullName != null && nativeModuleInstance.FullName.EndsWith(".exe") && processData.moduleWithLoadedLua == null)
+                var moduleName = nativeModuleInstance.FullName;
+
+                if (moduleName != null && (moduleName.EndsWith(".exe") || moduleName.IndexOf("lua", StringComparison.InvariantCultureIgnoreCase) != -1) && processData.moduleWithLoadedLua == null)
                 {
                     // Request the RemoteComponent to create the runtime and a module
                     DkmCustomMessage.Create(process.Connection, process, MessageToRemote.guid, MessageToRemote.createRuntime, null, null).SendLower();

--- a/LuaDkmDebuggerComponent/LocalComponent.cs
+++ b/LuaDkmDebuggerComponent/LocalComponent.cs
@@ -1966,7 +1966,8 @@ namespace LuaDkmDebuggerComponent
 
                 var moduleName = nativeModuleInstance.FullName;
 
-                if (moduleName != null && (moduleName.EndsWith(".exe") || moduleName.IndexOf("lua", StringComparison.InvariantCultureIgnoreCase) != -1) && processData.moduleWithLoadedLua == null)
+                if (moduleName != null && (moduleName.EndsWith(".exe") || Path.GetFileName(moduleName).IndexOf("lua", StringComparison.InvariantCultureIgnoreCase) != -1) &&
+                    processData.moduleWithLoadedLua == null)
                 {
                     // Request the RemoteComponent to create the runtime and a module
                     DkmCustomMessage.Create(process.Connection, process, MessageToRemote.guid, MessageToRemote.createRuntime, null, null).SendLower();


### PR DESCRIPTION
Add support for debugging Lua built as a DLL by also searching in modules that have "lua" in there name when looking for lua_newstate instead of just the main exe.