### PR TITLE
[FIX] Support opening filenames with spaces from tools panel.

### DIFF
--- a/LuaDkmDebuggerCommon/ToolWindows/ScriptListWindowControl.xaml.cs
+++ b/LuaDkmDebuggerCommon/ToolWindows/ScriptListWindowControl.xaml.cs
@@ -49,7 +49,8 @@ namespace LuaDkmDebugger.ToolWindows
 
                         var cmdobj = _state.dte.Commands.Item("File.OpenFile");
 
-                        string name = scriptEntry.path;
+                        // Support filenames and directories with whitespaces in path.
+                        string name = $"\"{scriptEntry.path}\"";
                         object none = null;
 
                         _state.dte.Commands.Raise(cmdobj.Guid, cmdobj.ID, name, none);


### PR DESCRIPTION
## What
- Adding whitespaces support in pathnames/filenames

## How
- Adding quotes for filename that is passed to command as argument

## Notes
- Fixing my own problem where LUA files are located in separate symlinked dir with long absolute path. I suspect there may be problems with other edge cases here so it can be passed for TODO list to add some validation / preparation of file paths.

## Tested
- Tested in VS community 2022