### PR TITLE
[FIX][PROPOSAL] Fix case sensitive check of filenames for symbols resolving.

### DIFF
--- a/LuaDkmDebuggerComponent/LocalComponent.cs
+++ b/LuaDkmDebuggerComponent/LocalComponent.cs
@@ -2609,8 +2609,11 @@ namespace LuaDkmDebuggerComponent
                         }
 
                         var fileName = script.Value.resolvedFileName;
+                        var sourceDocumentName = sourceFileId.DocumentName;
 
-                        if (sourceFileId.DocumentName == fileName)
+                        // Comparing file paths with ignoring case. 
+                        // OK for windows, by may be problematic with unix based operating systems.
+                        if (String.Equals(fileName, sourceDocumentName, StringComparison.OrdinalIgnoreCase))
                         {
                             var dataItem = new LuaResolvedDocumentItem
                             {

--- a/LuaDkmDebuggerComponent/Log.cs
+++ b/LuaDkmDebuggerComponent/Log.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using System.IO;
 
 namespace LuaDkmDebuggerComponent
@@ -51,7 +50,7 @@ namespace LuaDkmDebuggerComponent
         {
             try
             {
-                string formatted = $"{text} at {(DateTime.Now.Ticks / 10000.0) - startTime}ms";
+                string formatted = $"[{(DateTime.Now.Ticks / 10000.0) - startTime}] {text}";
 
                 System.Diagnostics.Debug.WriteLine(formatted);
 


### PR DESCRIPTION
## What
- Normalized log format to be more consistent and readable with similar lines
- Add case insensitive strings comparison when resolving LUA sources, fixes problems when names or folders are in camel case 
- As result, I am able to set breakpoints for files with upper case in pathname/filename

## How
- Generic comparison changes

## Notes
- I assume it is still as problematic solution as we already have. Windows OS does not care about case, but unix based operating systems (if extension is somehow used with them?) require strict equality of path. 
- Root of the problem may be originally in place where paths are transformed to lowercase before storing them

## Tested
- Tested in VS community 2022

## Upd / edit
May be related to how open-xray engine is build and how it maps files. Will investigate