### PR TITLE
Fix case sensitive check of filenames for symbols resolving.

### DIFF
--- a/LuaDkmDebuggerComponent/LocalComponent.cs
+++ b/LuaDkmDebuggerComponent/LocalComponent.cs
@@ -2609,8 +2609,12 @@ namespace LuaDkmDebuggerComponent
                         }
 
                         var fileName = script.Value.resolvedFileName;
+                        var sourceDocumentName = sourceFileId.DocumentName;
 
-                        if (sourceFileId.DocumentName == fileName)
+                        // Comparing file paths with ignoring case.
+                        // OK for windows, but may be problematic with unix based operating systems.
+                        // VS is not intended for usage with something else, so...
+                        if (String.Equals(fileName, sourceDocumentName, StringComparison.OrdinalIgnoreCase))
                         {
                             var dataItem = new LuaResolvedDocumentItem
                             {


### PR DESCRIPTION
Similar to https://github.com/WheretIB/LuaDkmDebugger/pull/26, without log update
Over time I have noticed that it is an actual issue + LuaJIT adds '@' as prefix for file paths (https://github.com/WheretIB/LuaDkmDebugger/blob/abf4f46ef988a8a95f4bd3df723c00a347cd6920/LuaDkmDebuggerComponent/LocalComponent.cs#L1387)

## What
- Add case insensitive strings comparison when resolving LUA sources, fixes problems when names or folders are in camel case 
- As result, I am able to set breakpoints for files with upper case in pathname/filename

## How
- Generic comparison changes

## Notes
- I assume it is still as problematic solution as we already have. Windows OS does not care about case, but unix based operating systems (if extension is somehow used with them?) require strict equality of path. 
- Root of the problem may be originally in place where paths are transformed to lowercase before storing them

## Tested
- Tested in VS community 2022
